### PR TITLE
Updated peering for external block passing

### DIFF
--- a/consensus/ethash/consensus.go
+++ b/consensus/ethash/consensus.go
@@ -711,7 +711,6 @@ func (ethash *Ethash) GetStopHash(chain consensus.ChainHeaderReader, difficultyC
 	for {
 		// Append the coincident and iterating header to the list
 		if header.Number[context].Cmp(big.NewInt(1)) < 0 {
-			log.Info("GetStopHash: Stopping on block height == 1", "difficultyContext", context)
 			break
 		}
 

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -2513,12 +2513,10 @@ func (bc *BlockChain) GetExternalBlocks(header *types.Header) ([]*types.External
 
 	// Do not run on block 1
 	if header.Number[context].Cmp(big.NewInt(1)) > 0 {
-		// Skip pending block
-		prevHeader := bc.GetHeaderByHash(header.ParentHash[context])
-		coincidentHeader, difficultyContext := bc.engine.GetCoincidentHeader(bc, context, prevHeader)
+		coincidentHeader, difficultyContext := bc.engine.GetCoincidentHeader(bc, context, header)
 
 		// Checking for nil prev or coincident headers
-		if prevHeader == nil {
+		if header == nil {
 			log.Info("GetExternalBlocks: prevHeader nil", "header", header.Hash())
 			return externalBlocks, nil
 		}
@@ -2529,7 +2527,7 @@ func (bc *BlockChain) GetExternalBlocks(header *types.Header) ([]*types.External
 		}
 
 		// If we are not getting the transactions immediately after the coincident block, return
-		if coincidentHeader.Number[context].Cmp(prevHeader.Number[context]) != 0 {
+		if coincidentHeader.Number[context].Cmp(header.Number[context]) != 0 {
 			return externalBlocks, nil
 		}
 		stopHash := bc.engine.GetStopHash(bc, difficultyContext, context, coincidentHeader)

--- a/core/state_processor.go
+++ b/core/state_processor.go
@@ -28,7 +28,6 @@ import (
 	"github.com/spruce-solutions/go-quai/core/types"
 	"github.com/spruce-solutions/go-quai/core/vm"
 	"github.com/spruce-solutions/go-quai/crypto"
-	"github.com/spruce-solutions/go-quai/log"
 	"github.com/spruce-solutions/go-quai/params"
 )
 
@@ -101,8 +100,6 @@ func (p *StateProcessor) Process(block *types.Block, statedb *state.StateDB, cfg
 			i++
 		}
 	}
-
-	log.Info("State Processor: External txs applied", "num", etxs)
 
 	// Iterate over and process the individual transactions
 	for _, tx := range block.Transactions() {

--- a/eth/downloader/queue.go
+++ b/eth/downloader/queue.go
@@ -370,7 +370,7 @@ func (q *queue) Schedule(headers []*types.Header, from uint64) []*types.Header {
 			q.externalBlockTaskPool[hash] = header
 			q.externalBlockTaskQueue.Push(header, -int64(header.Number[types.QuaiNetworkContext].Uint64()))
 		}
-		log.Info("Adding header to externalBlockTaskQueue")
+		log.Info("Adding header to externalBlockTaskQueue", "header", header.Hash())
 		inserts = append(inserts, header)
 		q.headerHead = hash
 		from++

--- a/eth/downloader/queue.go
+++ b/eth/downloader/queue.go
@@ -363,14 +363,13 @@ func (q *queue) Schedule(headers []*types.Header, from uint64) []*types.Header {
 				q.receiptTaskQueue.Push(header, -int64(header.Number[types.QuaiNetworkContext].Uint64()))
 			}
 		}
-		// Add to external block task queue
+		// Queue for external block retrieval
 		if _, ok := q.externalBlockTaskPool[hash]; ok {
 			log.Warn("Header already scheduled for external block fetch", "number", header.Number, "hash", hash)
 		} else {
 			q.externalBlockTaskPool[hash] = header
 			q.externalBlockTaskQueue.Push(header, -int64(header.Number[types.QuaiNetworkContext].Uint64()))
 		}
-		log.Info("Adding header to externalBlockTaskQueue", "header", header.Hash())
 		inserts = append(inserts, header)
 		q.headerHead = hash
 		from++

--- a/eth/fetcher/block_fetcher.go
+++ b/eth/fetcher/block_fetcher.go
@@ -804,7 +804,7 @@ func (f *BlockFetcher) importBlocks(peer string, block *types.Block, extBlocks [
 		case nil:
 			// All ok, quickly propagate to our peers
 			blockBroadcastOutTimer.UpdateSince(block.ReceivedAt)
-			go f.broadcastBlock(block, nil, true)
+			go f.broadcastBlock(block, extBlocks, true)
 
 		case consensus.ErrFutureBlock:
 			// Weird future block, don't fail, but neither propagate
@@ -823,7 +823,7 @@ func (f *BlockFetcher) importBlocks(peer string, block *types.Block, extBlocks [
 		}
 		// If import succeeded, broadcast the block
 		blockAnnounceOutTimer.UpdateSince(block.ReceivedAt)
-		go f.broadcastBlock(block, nil, false)
+		go f.broadcastBlock(block, extBlocks, false)
 
 		// Invoke the testing hook if needed
 		if f.importedHook != nil {

--- a/eth/handler.go
+++ b/eth/handler.go
@@ -18,7 +18,6 @@ package eth
 
 import (
 	"errors"
-	"fmt"
 	"math"
 	"math/big"
 	"sync"
@@ -214,11 +213,6 @@ func newHandler(config *handlerConfig) (*handler, error) {
 		}
 
 		log.Info("Adding external blocks from peer", "len", len(extBlocks), "number", blocks[0].Number())
-		// Print out the hash for the ext blocks
-		for i := 0; i < len(extBlocks); i++ {
-			fmt.Println(extBlocks[i].Hash(), extBlocks[i].Context(), extBlocks[i].Header().Number)
-		}
-
 		err := h.chain.AddExternalBlocks(extBlocks)
 		if err != nil {
 			log.Warn("Error importing external blocks", "number", blocks[0].Number(), "hash", blocks[0].Hash())

--- a/eth/handler.go
+++ b/eth/handler.go
@@ -18,6 +18,7 @@ package eth
 
 import (
 	"errors"
+	"fmt"
 	"math"
 	"math/big"
 	"sync"
@@ -213,6 +214,12 @@ func newHandler(config *handlerConfig) (*handler, error) {
 		}
 
 		log.Info("Adding external blocks from peer", "len", len(extBlocks), "number", blocks[0].Number())
+
+		// Print out the hash for the ext blocks
+		for i := 0; i < len(extBlocks); i++ {
+			fmt.Println(extBlocks[i].Hash())
+		}
+
 		err := h.chain.AddExternalBlocks(extBlocks)
 		if err != nil {
 			log.Warn("Error importing external blocks", "number", blocks[0].Number(), "hash", blocks[0].Hash())

--- a/eth/handler.go
+++ b/eth/handler.go
@@ -214,10 +214,9 @@ func newHandler(config *handlerConfig) (*handler, error) {
 		}
 
 		log.Info("Adding external blocks from peer", "len", len(extBlocks), "number", blocks[0].Number())
-
 		// Print out the hash for the ext blocks
 		for i := 0; i < len(extBlocks); i++ {
-			fmt.Println(extBlocks[i].Hash())
+			fmt.Println(extBlocks[i].Hash(), extBlocks[i].Context(), extBlocks[i].Header().Number)
 		}
 
 		err := h.chain.AddExternalBlocks(extBlocks)
@@ -532,6 +531,7 @@ func (h *handler) minedBroadcastLoop() {
 				if err != nil {
 					log.Info("Error sending external blocks to peer", "err", err)
 				}
+				fmt.Print("minedBroadcastLoop", header.Hash(), len(extBlocks))
 				h.BroadcastBlock(ev.Block, extBlocks, true)  // First propagate block to peers
 				h.BroadcastBlock(ev.Block, extBlocks, false) // Only then announce to the rest
 			}

--- a/eth/handler.go
+++ b/eth/handler.go
@@ -461,6 +461,7 @@ func (h *handler) BroadcastBlock(block *types.Block, extBlocks []*types.External
 		// Send the block to a subset of our peers
 		transfer := peers[:int(math.Sqrt(float64(len(peers))))]
 		for _, peer := range transfer {
+			log.Info("BroadcatBlock: calling asyncsendnewblock", "lenExtBlocks", len(extBlocks))
 			peer.AsyncSendNewBlock(block, td, extBlocks)
 		}
 		log.Trace("Propagated block", "hash", hash, "recipients", len(transfer), "duration", common.PrettyDuration(time.Since(block.ReceivedAt)))

--- a/eth/handler.go
+++ b/eth/handler.go
@@ -461,7 +461,6 @@ func (h *handler) BroadcastBlock(block *types.Block, extBlocks []*types.External
 		// Send the block to a subset of our peers
 		transfer := peers[:int(math.Sqrt(float64(len(peers))))]
 		for _, peer := range transfer {
-			log.Info("BroadcatBlock: calling asyncsendnewblock", "lenExtBlocks", len(extBlocks))
 			peer.AsyncSendNewBlock(block, td, extBlocks)
 		}
 		log.Trace("Propagated block", "hash", hash, "recipients", len(transfer), "duration", common.PrettyDuration(time.Since(block.ReceivedAt)))
@@ -532,7 +531,7 @@ func (h *handler) minedBroadcastLoop() {
 				if err != nil {
 					log.Info("Error sending external blocks to peer", "err", err)
 				}
-				fmt.Print("minedBroadcastLoop", header.Hash(), len(extBlocks))
+				log.Info("minedBroadcastLoop", "hash", header.Hash(), "extBlocks", len(extBlocks))
 				h.BroadcastBlock(ev.Block, extBlocks, true)  // First propagate block to peers
 				h.BroadcastBlock(ev.Block, extBlocks, false) // Only then announce to the rest
 			}

--- a/eth/protocols/eth/broadcast.go
+++ b/eth/protocols/eth/broadcast.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/spruce-solutions/go-quai/common"
 	"github.com/spruce-solutions/go-quai/core/types"
+	"github.com/spruce-solutions/go-quai/log"
 )
 
 const (
@@ -44,6 +45,7 @@ func (p *Peer) broadcastBlocks() {
 	for {
 		select {
 		case prop := <-p.queuedBlocks:
+			log.Info("broadcastBlocks", "numExtBlocks", len(prop.extBlocks))
 			if err := p.SendNewBlock(prop.block, prop.td, prop.extBlocks); err != nil {
 				return
 			}

--- a/eth/protocols/eth/broadcast.go
+++ b/eth/protocols/eth/broadcast.go
@@ -21,7 +21,6 @@ import (
 
 	"github.com/spruce-solutions/go-quai/common"
 	"github.com/spruce-solutions/go-quai/core/types"
-	"github.com/spruce-solutions/go-quai/log"
 )
 
 const (
@@ -45,7 +44,6 @@ func (p *Peer) broadcastBlocks() {
 	for {
 		select {
 		case prop := <-p.queuedBlocks:
-			log.Info("broadcastBlocks", "numExtBlocks", len(prop.extBlocks))
 			if err := p.SendNewBlock(prop.block, prop.td, prop.extBlocks); err != nil {
 				return
 			}

--- a/eth/protocols/eth/handlers.go
+++ b/eth/protocols/eth/handlers.go
@@ -264,12 +264,16 @@ func answerGetExtBlocksQuery(backend Backend, query GetExtBlocksPacket, peer *Pe
 		// Retrieve the requested block's external blocks
 		header := backend.Chain().GetHeaderByHash(hash)
 		results, err := backend.Chain().GetExternalBlocks(header)
+		log.Info("answerGetExtBlocks: ext blocks for hash", "hash", hash, "len", len(results))
+		for i := 0; i < len(results); i++ {
+			log.Info("answerGetExtBlocks", "hash", results[i].Hash(), "context", results[i].Context(), "num", results[i].Header().Number)
+		}
 		if err != nil {
 			log.Error("Unable to retrieve external blocks")
 		}
 		// If known, encode and queue for response packet
 		if encoded, err := rlp.EncodeToBytes(results); err != nil {
-			log.Error("Failed to encode receipt", "err", err)
+			log.Error("Failed to encode external block", "err", err)
 		} else {
 			extBlocks = append(extBlocks, encoded)
 			bytes += len(encoded)

--- a/eth/protocols/eth/handlers.go
+++ b/eth/protocols/eth/handlers.go
@@ -264,9 +264,10 @@ func answerGetExtBlocksQuery(backend Backend, query GetExtBlocksPacket, peer *Pe
 		// Retrieve the requested block's external blocks
 		header := backend.Chain().GetHeaderByHash(hash)
 		results, err := backend.Chain().GetExternalBlocks(header)
-		log.Info("answerGetExtBlocks: ext blocks for hash", "hash", hash, "len", len(results))
+		log.Info("answerGetExtBlocks: Retrieving ext blocks", "hash", hash, "len", len(results))
+		// Temp print, leave for now until we resolve all consensus.
 		for i := 0; i < len(results); i++ {
-			log.Info("answerGetExtBlocks", "hash", results[i].Hash(), "context", results[i].Context(), "num", results[i].Header().Number)
+			log.Info("answerGetExtBlocks:", "hash", results[i].Hash(), "context", results[i].Context(), "num", results[i].Header().Number)
 		}
 		if err != nil {
 			log.Error("Unable to retrieve external blocks")

--- a/eth/protocols/eth/peer.go
+++ b/eth/protocols/eth/peer.go
@@ -272,7 +272,7 @@ func (p *Peer) SendNewBlock(block *types.Block, td *big.Int, extBlocks []*types.
 	// Mark all the block hash as known, but ensure we don't overflow our limits
 	p.knownBlocks.Add(block.Hash())
 
-	log.Info("Sending external blocks with block", "len", len(extBlocks), "num", block.Header().Number[types.QuaiNetworkContext])
+	log.Info("Sending external blocks with block", "len", len(extBlocks), "number", block.Header().Number[types.QuaiNetworkContext])
 	return p2p.Send(p.rw, NewBlockMsg, &NewBlockPacket{
 		Block:     block,
 		TD:        td,

--- a/eth/sync.go
+++ b/eth/sync.go
@@ -17,6 +17,7 @@
 package eth
 
 import (
+	"fmt"
 	"math/big"
 	"sync/atomic"
 	"time"
@@ -260,6 +261,7 @@ func (h *handler) doSync(op *chainSyncOp) error {
 		if err != nil {
 			log.Info("Error sending external blocks to peer", "err", err)
 		}
+		fmt.Print("doSync", head.Hash(), len(extBlocks))
 		h.BroadcastBlock(head, extBlocks, false)
 	}
 	return nil

--- a/eth/sync.go
+++ b/eth/sync.go
@@ -256,7 +256,11 @@ func (h *handler) doSync(op *chainSyncOp) error {
 		// scenario will most often crop up in private and hackathon networks with
 		// degenerate connectivity, but it should be healthy for the mainnet too to
 		// more reliably update peers or the local TD state.
-		h.BroadcastBlock(head, nil, false)
+		extBlocks, err := h.chain.GetExternalBlocks(head.Header())
+		if err != nil {
+			log.Info("Error sending external blocks to peer", "err", err)
+		}
+		h.BroadcastBlock(head, extBlocks, false)
 	}
 	return nil
 }

--- a/eth/sync.go
+++ b/eth/sync.go
@@ -17,7 +17,6 @@
 package eth
 
 import (
-	"fmt"
 	"math/big"
 	"sync/atomic"
 	"time"
@@ -261,7 +260,6 @@ func (h *handler) doSync(op *chainSyncOp) error {
 		if err != nil {
 			log.Info("Error sending external blocks to peer", "err", err)
 		}
-		fmt.Print("doSync", head.Hash(), len(extBlocks))
 		h.BroadcastBlock(head, extBlocks, false)
 	}
 	return nil


### PR DESCRIPTION
Updated several items:
- Proper starting header when passing ext blocks since we are not given a candidate
- Updated broadcast handler to pass external blocks
- Revised logging