### PR TITLE
Fixed ReadAllHashes improperly removing external blocks

### DIFF
--- a/core/rawdb/accessors_chain.go
+++ b/core/rawdb/accessors_chain.go
@@ -328,9 +328,9 @@ func ReadHeaderRLP(db ethdb.Reader, hash common.Hash, number uint64) rlp.RawValu
 }
 
 // ReadExternalHeaderRLP retrieves a block header in its raw RLP database encoding.
-func ReadExternalHeaderRLP(db ethdb.Reader, hash common.Hash, number uint64) rlp.RawValue {
+func ReadExternalHeaderRLP(db ethdb.Reader, hash common.Hash, number uint64, context uint64) rlp.RawValue {
 	// look up the data in leveldb.
-	data, _ := db.Get(headerKey(number, hash))
+	data, _ := db.Get(extHeaderKey(number, context, hash))
 	if len(data) > 0 {
 		return data
 	}
@@ -363,8 +363,8 @@ func ReadHeader(db ethdb.Reader, hash common.Hash, number uint64) *types.Header 
 }
 
 // ReadExternalHeader retrieves the block header corresponding to the hash.
-func ReadExternalHeader(db ethdb.Reader, hash common.Hash, number uint64) *types.Header {
-	data := ReadExternalHeaderRLP(db, hash, number)
+func ReadExternalHeader(db ethdb.Reader, hash common.Hash, number uint64, context uint64) *types.Header {
+	data := ReadExternalHeaderRLP(db, hash, number, context)
 	if len(data) == 0 {
 		return nil
 	}
@@ -410,7 +410,7 @@ func WriteExternalHeader(db ethdb.KeyValueWriter, header *types.Header, context 
 	if err != nil {
 		log.Crit("Failed to RLP encode header", "err", err)
 	}
-	key := headerKey(number, hash)
+	key := extHeaderKey(number, context, hash)
 	if err := db.Put(key, data); err != nil {
 		log.Crit("Failed to store header", "err", err)
 	}
@@ -501,6 +501,7 @@ func WriteBodyRLP(db ethdb.KeyValueWriter, hash common.Hash, number uint64, rlp 
 
 // WriteBodyRLP stores an RLP encoded block body into the database.
 func WriteExternalBodyRLP(db ethdb.KeyValueWriter, hash common.Hash, number uint64, context uint64, rlp rlp.RawValue) {
+	fmt.Println("WriteExternalBodyRLP:", number, context, hash)
 	if err := db.Put(extBlockBodyKey(number, context, hash), rlp); err != nil {
 		log.Crit("Failed to store block body", "err", err)
 	}
@@ -855,7 +856,7 @@ func WriteBlock(db ethdb.KeyValueWriter, block *types.Block) {
 // back from the stored header and body. If either the header or body could not
 // be retrieved nil is returned.
 func ReadExternalBlock(db ethdb.Reader, hash common.Hash, number uint64, context uint64) *types.ExternalBlock {
-	header := ReadExternalHeader(db, hash, number)
+	header := ReadExternalHeader(db, hash, number, context)
 	if header == nil {
 		return nil
 	}

--- a/core/rawdb/accessors_chain.go
+++ b/core/rawdb/accessors_chain.go
@@ -501,7 +501,6 @@ func WriteBodyRLP(db ethdb.KeyValueWriter, hash common.Hash, number uint64, rlp 
 
 // WriteBodyRLP stores an RLP encoded block body into the database.
 func WriteExternalBodyRLP(db ethdb.KeyValueWriter, hash common.Hash, number uint64, context uint64, rlp rlp.RawValue) {
-	fmt.Println("WriteExternalBodyRLP:", number, context, hash)
 	if err := db.Put(extBlockBodyKey(number, context, hash), rlp); err != nil {
 		log.Crit("Failed to store block body", "err", err)
 	}

--- a/core/rawdb/schema.go
+++ b/core/rawdb/schema.go
@@ -152,6 +152,11 @@ func headerKey(number uint64, hash common.Hash) []byte {
 	return append(append(headerPrefix, encodeBlockNumber(number)...), hash.Bytes()...)
 }
 
+// extHeaderKey = headerPrefix + num (uint64 big endian) + location + context + hash
+func extHeaderKey(number uint64, context uint64, hash common.Hash) []byte {
+	return append(append(append(headerPrefix, encodeBlockNumber(number)...), encodeBlockNumber(context)...), hash.Bytes()...)
+}
+
 // headerTDKey = headerPrefix + num (uint64 big endian) + hash + headerTDSuffix
 func headerTDKey(number uint64, hash common.Hash) []byte {
 	return append(headerKey(number, hash), headerTDSuffix...)


### PR DESCRIPTION
Added unique key to external headers so they do not conflict with operations on local headers.