### PR TITLE
V2 Block Generator

### DIFF
--- a/consensus/blake3/consensus.go
+++ b/consensus/blake3/consensus.go
@@ -848,11 +848,7 @@ func verifyInsideLocation(location []byte, number []*big.Int, config *params.Cha
 	zoneLocation := int(location[1])
 
 	switch {
-	/*	case config.IsLovelace(number[0]): // Lovelace = [3,4,4]
-			return checkInsideCurrent(regionLocation, zoneLocation, params.LovelaceOntology)
-		case config.IsTuring(number[0]): // Turing = [3,3,4]
-			return checkInsideCurrent(regionLocation, zoneLocation, params.TuringOntology) */
-	case config.IsFuller(number[0]): // Fuller = [3,3,3]
+	case config.IsFuller(number[0]): // Fuller = [3,3]
 		return checkInsideCurrent(regionLocation, zoneLocation, params.FullerOntology)
 	default:
 		return consensus.ErrInvalidOntology
@@ -861,10 +857,10 @@ func verifyInsideLocation(location []byte, number []*big.Int, config *params.Cha
 
 // Verifies that Location is valid inside current MapContext ontology.
 func checkInsideCurrent(regionLoc int, zoneLoc int, ontology []int) error {
-	if len(ontology) < regionLoc {
+	if regionLoc < 1 || regionLoc > ontology[0] {
 		return consensus.ErrInvalidOntology
 	}
-	if ontology[regionLoc-1] < zoneLoc {
+	if zoneLoc < 1 || zoneLoc > ontology[1] {
 		return consensus.ErrInvalidOntology
 	}
 	return nil

--- a/core/chain_makers.go
+++ b/core/chain_makers.go
@@ -243,9 +243,9 @@ func GenerateChain(config *params.ChainConfig, parent *types.Block, engine conse
 	return blocks, receipts
 }
 
-func makeHeader(config *params.ChainConfig, chain consensus.ChainReader, parent *types.Block, order int, state *state.StateDB, engine consensus.Engine) *types.Header {
-	// return genesis block as itself for first block in chain
-	if parent.Header().Number[0].Cmp(big.NewInt(0)) == 0 {
+func makeHeader(genCheck bool, config *params.ChainConfig, chain consensus.ChainReader, parent *types.Block, order int, state *state.StateDB, engine consensus.Engine) *types.Header {
+	// return genesis block as first block in chain (only triggers once)
+	if genCheck {
 		return parent.Header()
 	}
 
@@ -388,48 +388,17 @@ func (cr *fakeChainReader) GetLinkExternalBlocks(header *types.Header) ([]*types
 // Blocks created by GenerateNetwork do not contain valid proof of work values.
 // Inserting them into BlockChain requires use of a TestPoW in order to test and
 // verify the correct operation of the Proof-of-Work algorithm.
-func GenerateNetwork(primeConfig *params.ChainConfig, regionConfig params.ChainConfig, zoneConfig params.ChainConfig, parent *types.Block, orders []int, startNumber []int, engine consensus.Engine, db ethdb.Database, gen func(int, *BlockGen)) ([]*types.Block, []types.Receipts) {
-	// the first config must be the Prime
-	if primeConfig != params.MainnetPrimeChainConfig {
-		print("must have MainnetPrimeChainConfig as first config")
-	}
-	// check second config for Region
-	if !(regionConfig.ChainID.Cmp(params.MainnetRegionChainConfigs[0].ChainID) == 0 || regionConfig.ChainID.Cmp(params.MainnetRegionChainConfigs[1].ChainID) == 0 || regionConfig.ChainID.Cmp(params.MainnetRegionChainConfigs[2].ChainID) == 0) {
-		print("must have a MainnetRegionChainConfig as second config")
-	}
-	// check third config for Zone in Region
-	if !(zoneConfig.ChainID.Cmp(params.MainnetZoneChainConfigs[regionConfig.Location[0]-1][0].ChainID) == 0 || zoneConfig.ChainID.Cmp(params.MainnetZoneChainConfigs[regionConfig.Location[0]-1][1].ChainID) == 0 || zoneConfig.ChainID.Cmp(params.MainnetZoneChainConfigs[regionConfig.Location[0]-1][2].ChainID) == 0) {
-		print("must have a MainnetZoneConfig as third config")
-	}
-
-	n := len(orders)
+func GenerateNetwork(genesisCheck bool, config *params.ChainConfig, parent *types.Block, order int, startNumber [3]int, n int, engine consensus.Engine, db ethdb.Database, gen func(int, *BlockGen)) ([]*types.Block, []types.Receipts) {
+	// initialize blocks and receipts
 	blocks, receipts := make(types.Blocks, n), make([]types.Receipts, n)
 
 	// associate chainreaders and configs for correct block context placement
-	chainreaders, configs := []fakeChainReader{}, []params.ChainConfig{}
-	for _, context := range orders {
-		switch context {
-		case 0:
-			chainreaders = append(chainreaders, fakeChainReader{config: primeConfig})
-			configs = append(configs, *primeConfig)
-		case 1:
-			chainreaders = append(chainreaders, fakeChainReader{config: &regionConfig})
-			configs = append(configs, regionConfig)
-		case 2:
-			chainreaders = append(chainreaders, fakeChainReader{config: &zoneConfig})
-			configs = append(configs, zoneConfig)
-		default:
-			print("contexts must be 0, 1, or 2")
-		}
-	}
+	chainreader := fakeChainReader{config: config}
 
-	genblock := func(i int, parent *types.Block, context int, statedb *state.StateDB, chainreaders []fakeChainReader, configs []params.ChainConfig) (*types.Block, types.Receipts) {
-		// select appropriate fakeChainReader for block creation
-		chainreader := chainreaders[i]
-		config := configs[i]
+	genblock := func(genCheck bool, i int, parent *types.Block, order int, statedb *state.StateDB, chainreader fakeChainReader, config params.ChainConfig) (*types.Block, types.Receipts) {
 
 		b := &BlockGen{i: i, chain: blocks, parent: parent, statedb: statedb, config: &config, engine: engine}
-		b.header = makeHeader(&config, &chainreader, parent, context, statedb, b.engine)
+		b.header = makeHeader(genCheck, &config, &chainreader, parent, order, statedb, b.engine)
 
 		// Execute any user modifications to the block
 		if gen != nil {
@@ -458,7 +427,10 @@ func GenerateNetwork(primeConfig *params.ChainConfig, regionConfig params.ChainC
 		if err != nil {
 			panic(err)
 		}
-		block, receipt := genblock(i, parent, orders[i], statedb, chainreaders, configs)
+		block, receipt := genblock(genesisCheck, i, parent, order, statedb, chainreader, *config)
+		if genesisCheck { // in order to generate genesis first and only once
+			genesisCheck = false
+		}
 		blocks[i] = block
 		receipts[i] = receipt
 		parent = block

--- a/core/chain_makers.go
+++ b/core/chain_makers.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/spruce-solutions/go-quai/common"
 	"github.com/spruce-solutions/go-quai/consensus"
+	"github.com/spruce-solutions/go-quai/consensus/blake3"
 	"github.com/spruce-solutions/go-quai/consensus/misc"
 	"github.com/spruce-solutions/go-quai/core/state"
 	"github.com/spruce-solutions/go-quai/core/types"
@@ -73,7 +74,7 @@ func (b *BlockGen) SetNonce(nonce types.BlockNonce) {
 
 // SetDifficulty sets the difficulty field of the generated block. This method is
 // useful for Clique tests where the difficulty does not depend on time. For the
-// ethash tests, please use OffsetTime, which implicitly recalculates the diff.
+// blake3 tests, please use OffsetTime, which implicitly recalculates the diff.
 func (b *BlockGen) SetDifficulty(diff *big.Int) {
 	b.header.Difficulty[types.QuaiNetworkContext] = diff
 }
@@ -196,6 +197,10 @@ func (b *BlockGen) OffsetTime(seconds int64) {
 // values. Inserting them into BlockChain requires use of FakePow or
 // a similar non-validating proof of work implementation.
 func GenerateChain(config *params.ChainConfig, parent *types.Block, engine consensus.Engine, db ethdb.Database, n int, gen func(int, *BlockGen)) ([]*types.Block, []types.Receipts) {
+	if config.ChainID == nil { // for testing purposes
+		config = params.TestChainConfig
+	}
+
 	if config == nil {
 		config = params.TestChainConfig
 	}
@@ -203,7 +208,7 @@ func GenerateChain(config *params.ChainConfig, parent *types.Block, engine conse
 	chainreader := &fakeChainReader{config: config}
 	genblock := func(i int, parent *types.Block, statedb *state.StateDB) (*types.Block, types.Receipts) {
 		b := &BlockGen{i: i, chain: blocks, parent: parent, statedb: statedb, config: config, engine: engine}
-		b.header = makeHeader(chainreader, parent, statedb, b.engine)
+		// b.header = makeHeader(chainreader, parent, statedb, b.engine)
 
 		// Execute any user modifications to the block
 		if gen != nil {
@@ -238,57 +243,78 @@ func GenerateChain(config *params.ChainConfig, parent *types.Block, engine conse
 	return blocks, receipts
 }
 
-func makeHeader(chain consensus.ChainReader, parent *types.Block, state *state.StateDB, engine consensus.Engine) *types.Header {
-	var time uint64
-	if parent.Time() == 0 {
-		time = 10
-	} else {
-		time = parent.Time() + 10 // block time is fixed at 10 seconds
+func makeHeader(config *params.ChainConfig, chain consensus.ChainReader, parent *types.Block, order int, state *state.StateDB, engine consensus.Engine) *types.Header {
+	// return genesis block as itself for first block in chain
+	if parent.Header().Number[0].Cmp(big.NewInt(0)) == 0 {
+		return parent.Header()
 	}
 
+	// initialization of header
 	baseFee := misc.CalcBaseFee(chain.Config(), parent.Header(), chain.GetHeaderByNumber, chain.GetUnclesInChain, chain.GetGasUsedInChain)
-
 	header := &types.Header{
-		Coinbase:    []common.Address{common.Address{}, common.Address{}, common.Address{}},
-		Number:      []*big.Int{big.NewInt(int64(1)), big.NewInt(int64(1)), big.NewInt(int64(1))},
-		ParentHash:  []common.Hash{common.Hash{}, common.Hash{}, common.Hash{}},
-		Root:        []common.Hash{common.Hash{}, common.Hash{}, common.Hash{}},
-		Difficulty:  []*big.Int{big.NewInt(1), big.NewInt(1), big.NewInt(1)},
-		UncleHash:   types.EmptyUncleHash,
-		TxHash:      types.EmptyRootHash,
-		ReceiptHash: types.EmptyRootHash,
-		Bloom:       []types.Bloom{types.Bloom{}, types.Bloom{}, types.Bloom{}},
-		Time:        time,
-		BaseFee:     []*big.Int{baseFee, baseFee, baseFee},
-		GasLimit:    []uint64{0, 0, 0},
-		GasUsed:     []uint64{0, 0, 0},
-		Extra:       [][]byte{[]byte(nil), []byte(nil), []byte(nil)},
-	}
-	header.GasLimit[types.QuaiNetworkContext] = parent.GasLimit()
-
-	parentHeader := &types.Header{
-		Number:     []*big.Int{big.NewInt(int64(1)), big.NewInt(int64(1)), big.NewInt(int64(1))},
-		Difficulty: []*big.Int{big.NewInt(1), big.NewInt(1), big.NewInt(1)},
-		UncleHash:  types.EmptyUncleHash,
-		Time:       time - 10,
+		ParentHash:        make([]common.Hash, 3),
+		Number:            []*big.Int{new(big.Int).SetUint64(0), new(big.Int).SetUint64(0), new(big.Int).SetUint64(0)},
+		Extra:             make([][]byte, 3),
+		Time:              uint64(0),
+		BaseFee:           []*big.Int{baseFee, baseFee, baseFee},
+		GasLimit:          make([]uint64, 3),
+		Coinbase:          make([]common.Address, 3),
+		Difficulty:        make([]*big.Int, 3),
+		NetworkDifficulty: make([]*big.Int, 3),
+		Root:              make([]common.Hash, 3),
+		TxHash:            make([]common.Hash, 3),
+		ReceiptHash:       make([]common.Hash, 3),
+		GasUsed:           make([]uint64, 3),
+		Bloom:             make([]types.Bloom, 3),
+		Location:          chain.Config().Location,
 	}
 
-	if chain.Config().IsLondon(header.Number[types.QuaiNetworkContext]) {
-		if !chain.Config().IsLondon(parent.Number()) {
-			parentGasLimit := parent.GasLimit() * params.ElasticityMultiplier
-			header.GasLimit[types.QuaiNetworkContext] = CalcGasLimit(parentGasLimit, parent.GasUsed(), 0)
-		}
+	// same across orders
+	header.Time = parent.Time() + uint64(10)
+	gasLimit := CalcGasLimit(parent.GasLimit(), parent.GasUsed(), len(parent.Uncles()))
+	header.GasLimit = []uint64{gasLimit, gasLimit, gasLimit}
+
+	switch order {
+	case 2: // Zone
+		// fill ParentHash values
+		header.ParentHash[0] = parent.Header().ParentHash[0]
+		header.ParentHash[1] = parent.Header().ParentHash[1]
+		header.ParentHash[2] = parent.Hash()
+		// fill Number values
+		header.Number[0] = parent.Header().Number[0]
+		header.Number[1] = parent.Header().Number[1]
+		header.Number[2].Add(parent.Header().Number[2], common.Big1)
+		// fill Difficulty values
+		header.Difficulty[0] = parent.Header().Difficulty[0]
+		header.Difficulty[1] = parent.Header().Difficulty[1]
+		header.Difficulty[2] = blake3.CalcDifficulty(config, header.Time, parent.Header(), 2)
+	case 1: // Region
+		// fill ParentHash values
+		header.ParentHash[0] = parent.Header().ParentHash[0]
+		header.ParentHash[1] = parent.Hash()
+		header.ParentHash[2] = header.ParentHash[1]
+		// fill Number values
+		header.Number[0] = parent.Header().Number[0]
+		header.Number[1].Add(parent.Header().Number[1], common.Big1)
+		header.Number[2].Add(parent.Header().Number[2], common.Big1)
+		// fill Difficulty values
+		header.Difficulty[0] = parent.Header().Difficulty[0]
+		header.Difficulty[1] = blake3.CalcDifficulty(config, header.Time, parent.Header(), 1)
+		header.Difficulty[2] = blake3.CalcDifficulty(config, header.Time, parent.Header(), 2)
+	case 0: // Prime
+		// fill ParentHash values
+		header.ParentHash[0] = parent.Hash()
+		header.ParentHash[1] = header.ParentHash[0] // take new header[0] value to reduce compute
+		header.ParentHash[2] = header.ParentHash[0]
+		// fill Number values
+		header.Number[0].Add(parent.Header().Number[0], common.Big1)
+		header.Number[1].Add(parent.Header().Number[1], common.Big1)
+		header.Number[2].Add(parent.Header().Number[2], common.Big1)
+		// fill Difficulty values
+		header.Difficulty[0] = blake3.CalcDifficulty(config, header.Time, parent.Header(), 0)
+		header.Difficulty[1] = blake3.CalcDifficulty(config, header.Time, parent.Header(), 1)
+		header.Difficulty[2] = blake3.CalcDifficulty(config, header.Time, parent.Header(), 2)
 	}
-
-	parentHeader.Number[types.QuaiNetworkContext] = new(big.Int).Add(parent.Number(), common.Big1)
-	parentHeader.Difficulty[types.QuaiNetworkContext] = parent.Difficulty()
-	parentHeader.UncleHash[types.QuaiNetworkContext] = parent.UncleHash()
-
-	header.Root[types.QuaiNetworkContext] = state.IntermediateRoot(chain.Config().IsEIP158(parent.Number()))
-	header.ParentHash[types.QuaiNetworkContext] = parent.Hash()
-	header.Coinbase[types.QuaiNetworkContext] = parent.Coinbase()
-	header.Difficulty[types.QuaiNetworkContext] = engine.CalcDifficulty(chain, time, parentHeader, types.QuaiNetworkContext)
-	header.Number[types.QuaiNetworkContext] = new(big.Int).Add(parent.Number(), common.Big1)
 
 	return header
 }
@@ -340,7 +366,102 @@ func (cr *fakeChainReader) GetGasUsedInChain(block *types.Block, length int) int
 func (cr *fakeChainReader) GetExternalBlocks(header *types.Header) ([]*types.ExternalBlock, error) {
 	return nil, nil
 }
-
 func (cr *fakeChainReader) GetLinkExternalBlocks(header *types.Header) ([]*types.ExternalBlock, error) {
 	return nil, nil
+}
+
+// GenerateNetwork creates a network of n blocks in c contexts. The first block's
+// parent will be the provided parent. db is used to store intermediate states
+// and should contain the parent's state trie.
+
+// configs should contain the respective config settings being tested. This must
+// include a valid slice of Prime, Region, and Zone mining locations. This is
+// necessary for testing interchain linkages through coincident blocks as well
+// as transactions flowing through them. The array of ints in c represent
+// the intended order of contexts to be mined.
+
+// The generator function is called with a new block generator for every
+// block. Any transactions and uncles added to the generator become part of the
+// block. If gen is nil, the blocks will be empty and their coinbase will
+// be the zero address.
+
+// Blocks created by GenerateNetwork do not contain valid proof of work values.
+// Inserting them into BlockChain requires use of a TestPoW in order to test and
+// verify the correct operation of the Proof-of-Work algorithm.
+func GenerateNetwork(primeConfig *params.ChainConfig, regionConfig params.ChainConfig, zoneConfig params.ChainConfig, parent *types.Block, orders []int, startNumber []int, engine consensus.Engine, db ethdb.Database, gen func(int, *BlockGen)) ([]*types.Block, []types.Receipts) {
+	// the first config must be the Prime
+	if primeConfig != params.MainnetPrimeChainConfig {
+		print("must have MainnetPrimeChainConfig as first config")
+	}
+	// check second config for Region
+	if !(regionConfig.ChainID.Cmp(params.MainnetRegionChainConfigs[0].ChainID) == 0 || regionConfig.ChainID.Cmp(params.MainnetRegionChainConfigs[1].ChainID) == 0 || regionConfig.ChainID.Cmp(params.MainnetRegionChainConfigs[2].ChainID) == 0) {
+		print("must have a MainnetRegionChainConfig as second config")
+	}
+	// check third config for Zone in Region
+	if !(zoneConfig.ChainID.Cmp(params.MainnetZoneChainConfigs[regionConfig.Location[0]-1][0].ChainID) == 0 || zoneConfig.ChainID.Cmp(params.MainnetZoneChainConfigs[regionConfig.Location[0]-1][1].ChainID) == 0 || zoneConfig.ChainID.Cmp(params.MainnetZoneChainConfigs[regionConfig.Location[0]-1][2].ChainID) == 0) {
+		print("must have a MainnetZoneConfig as third config")
+	}
+
+	n := len(orders)
+	blocks, receipts := make(types.Blocks, n), make([]types.Receipts, n)
+
+	// associate chainreaders and configs for correct block context placement
+	chainreaders, configs := []fakeChainReader{}, []params.ChainConfig{}
+	for _, context := range orders {
+		switch context {
+		case 0:
+			chainreaders = append(chainreaders, fakeChainReader{config: primeConfig})
+			configs = append(configs, *primeConfig)
+		case 1:
+			chainreaders = append(chainreaders, fakeChainReader{config: &regionConfig})
+			configs = append(configs, regionConfig)
+		case 2:
+			chainreaders = append(chainreaders, fakeChainReader{config: &zoneConfig})
+			configs = append(configs, zoneConfig)
+		default:
+			print("contexts must be 0, 1, or 2")
+		}
+	}
+
+	genblock := func(i int, parent *types.Block, context int, statedb *state.StateDB, chainreaders []fakeChainReader, configs []params.ChainConfig) (*types.Block, types.Receipts) {
+		// select appropriate fakeChainReader for block creation
+		chainreader := chainreaders[i]
+		config := configs[i]
+
+		b := &BlockGen{i: i, chain: blocks, parent: parent, statedb: statedb, config: &config, engine: engine}
+		b.header = makeHeader(&config, &chainreader, parent, context, statedb, b.engine)
+
+		// Execute any user modifications to the block
+		if gen != nil {
+			gen(i, b)
+		}
+
+		if b.engine != nil {
+			// Finalize and seal the block
+			block, _ := b.engine.FinalizeAndAssemble(&chainreader, b.header, statedb, b.txs, b.uncles, b.receipts)
+
+			// Write state changes to db
+			root, err := statedb.Commit(config.IsEIP158(b.header.Number[types.QuaiNetworkContext]))
+			if err != nil {
+				panic(fmt.Sprintf("state write error: %v", err))
+			}
+			if err := statedb.Database().TrieDB().Commit(root, false, nil); err != nil {
+				panic(fmt.Sprintf("trie write error: %v", err))
+			}
+			return block, b.receipts
+		}
+		return nil, nil
+	}
+
+	for i := 0; i < n; i++ {
+		statedb, err := state.New(parent.Root(), state.NewDatabase(db), nil)
+		if err != nil {
+			panic(err)
+		}
+		block, receipt := genblock(i, parent, orders[i], statedb, chainreaders, configs)
+		blocks[i] = block
+		receipts[i] = receipt
+		parent = block
+	}
+	return blocks, receipts
 }

--- a/core/chain_makers.go
+++ b/core/chain_makers.go
@@ -49,6 +49,79 @@ type BlockGen struct {
 	engine consensus.Engine
 }
 
+// GenerateChain creates a chain of n blocks. The first block's
+// parent will be the provided parent. db is used to store
+// intermediate states and should contain the parent's state trie.
+//
+// The generator function is called with a new block generator for
+// every block. Any transactions and uncles added to the generator
+// become part of the block. If gen is nil, the blocks will be empty
+// and their coinbase will be the zero address.
+//
+// Blocks created by GenerateChain do not contain valid proof of work
+// values. Inserting them into BlockChain requires use of FakePow or
+// a similar non-validating proof of work implementation.
+func GenerateChain(config *params.ChainConfig, parent *types.Block, engine consensus.Engine, db ethdb.Database, n int, gen func(int, *BlockGen)) ([]*types.Block, []types.Receipts) {
+	if config == nil {
+		config = params.TestChainConfig
+	}
+	blocks, receipts := make(types.Blocks, n), make([]types.Receipts, n)
+	chainreader := &fakeChainReader{config: config}
+	genblock := func(i int, parent *types.Block, statedb *state.StateDB) (*types.Block, types.Receipts) {
+		b := &BlockGen{i: i, chain: blocks, parent: parent, statedb: statedb, config: config, engine: engine}
+		b.header = makeHeader(false, config, chainreader, parent, 0, statedb, b.engine)
+
+		// Execute any user modifications to the block
+		if gen != nil {
+			gen(i, b)
+		}
+		if b.engine != nil {
+			// Finalize and seal the block
+			block, _ := b.engine.FinalizeAndAssemble(chainreader, b.header, statedb, b.txs, b.uncles, b.receipts)
+
+			// Write state changes to db
+			root, err := statedb.Commit(config.IsEIP158(b.header.Number[types.QuaiNetworkContext]))
+			if err != nil {
+				panic(fmt.Sprintf("state write error: %v", err))
+			}
+			if err := statedb.Database().TrieDB().Commit(root, false, nil); err != nil {
+				panic(fmt.Sprintf("trie write error: %v", err))
+			}
+			return block, b.receipts
+		}
+		return nil, nil
+	}
+	for i := 0; i < n; i++ {
+		statedb, err := state.New(parent.Root(), state.NewDatabase(db), nil)
+		if err != nil {
+			panic(err)
+		}
+		block, receipt := genblock(i, parent, statedb)
+		blocks[i] = block
+		receipts[i] = receipt
+		parent = block
+	}
+	return blocks, receipts
+}
+
+// makeHeaderChain creates a deterministic chain of headers rooted at parent.
+func makeHeaderChain(parent *types.Header, n int, engine consensus.Engine, db ethdb.Database, seed int) []*types.Header {
+	blocks := makeBlockChain(types.NewBlockWithHeader(parent), n, engine, db, seed)
+	headers := make([]*types.Header, len(blocks))
+	for i, block := range blocks {
+		headers[i] = block.Header()
+	}
+	return headers
+}
+
+// makeBlockChain creates a deterministic chain of blocks rooted at parent.
+func makeBlockChain(parent *types.Block, n int, engine consensus.Engine, db ethdb.Database, seed int) []*types.Block {
+	blocks, _ := GenerateChain(params.TestChainConfig, parent, engine, db, n, func(i int, b *BlockGen) {
+		b.SetCoinbase(common.Address{0: byte(seed), 19: byte(i)})
+	})
+	return blocks
+}
+
 // SetCoinbase sets the coinbase of the generated block.
 // It can be called at most once.
 func (b *BlockGen) SetCoinbase(addr common.Address) {
@@ -184,65 +257,6 @@ func (b *BlockGen) OffsetTime(seconds int64) {
 	b.header.Difficulty[types.QuaiNetworkContext] = b.engine.CalcDifficulty(chainreader, b.header.Time, b.parent.Header(), types.QuaiNetworkContext)
 }
 
-// GenerateChain creates a chain of n blocks. The first block's
-// parent will be the provided parent. db is used to store
-// intermediate states and should contain the parent's state trie.
-//
-// The generator function is called with a new block generator for
-// every block. Any transactions and uncles added to the generator
-// become part of the block. If gen is nil, the blocks will be empty
-// and their coinbase will be the zero address.
-//
-// Blocks created by GenerateChain do not contain valid proof of work
-// values. Inserting them into BlockChain requires use of FakePow or
-// a similar non-validating proof of work implementation.
-func GenerateChain(config *params.ChainConfig, parent *types.Block, engine consensus.Engine, db ethdb.Database, n int, gen func(int, *BlockGen)) ([]*types.Block, []types.Receipts) {
-	if config.ChainID == nil { // for testing purposes
-		config = params.TestChainConfig
-	}
-
-	if config == nil {
-		config = params.TestChainConfig
-	}
-	blocks, receipts := make(types.Blocks, n), make([]types.Receipts, n)
-	chainreader := &fakeChainReader{config: config}
-	genblock := func(i int, parent *types.Block, statedb *state.StateDB) (*types.Block, types.Receipts) {
-		b := &BlockGen{i: i, chain: blocks, parent: parent, statedb: statedb, config: config, engine: engine}
-		// b.header = makeHeader(chainreader, parent, statedb, b.engine)
-
-		// Execute any user modifications to the block
-		if gen != nil {
-			gen(i, b)
-		}
-		if b.engine != nil {
-			// Finalize and seal the block
-			block, _ := b.engine.FinalizeAndAssemble(chainreader, b.header, statedb, b.txs, b.uncles, b.receipts)
-
-			// Write state changes to db
-			root, err := statedb.Commit(config.IsEIP158(b.header.Number[types.QuaiNetworkContext]))
-			if err != nil {
-				panic(fmt.Sprintf("state write error: %v", err))
-			}
-			if err := statedb.Database().TrieDB().Commit(root, false, nil); err != nil {
-				panic(fmt.Sprintf("trie write error: %v", err))
-			}
-			return block, b.receipts
-		}
-		return nil, nil
-	}
-	for i := 0; i < n; i++ {
-		statedb, err := state.New(parent.Root(), state.NewDatabase(db), nil)
-		if err != nil {
-			panic(err)
-		}
-		block, receipt := genblock(i, parent, statedb)
-		blocks[i] = block
-		receipts[i] = receipt
-		parent = block
-	}
-	return blocks, receipts
-}
-
 func makeHeader(genCheck bool, config *params.ChainConfig, chain consensus.ChainReader, parent *types.Block, order int, state *state.StateDB, engine consensus.Engine) *types.Header {
 	// return genesis block as first block in chain (only triggers once)
 	if genCheck {
@@ -319,24 +333,6 @@ func makeHeader(genCheck bool, config *params.ChainConfig, chain consensus.Chain
 	return header
 }
 
-// makeHeaderChain creates a deterministic chain of headers rooted at parent.
-func makeHeaderChain(parent *types.Header, n int, engine consensus.Engine, db ethdb.Database, seed int) []*types.Header {
-	blocks := makeBlockChain(types.NewBlockWithHeader(parent), n, engine, db, seed)
-	headers := make([]*types.Header, len(blocks))
-	for i, block := range blocks {
-		headers[i] = block.Header()
-	}
-	return headers
-}
-
-// makeBlockChain creates a deterministic chain of blocks rooted at parent.
-func makeBlockChain(parent *types.Block, n int, engine consensus.Engine, db ethdb.Database, seed int) []*types.Block {
-	blocks, _ := GenerateChain(params.TestChainConfig, parent, engine, db, n, func(i int, b *BlockGen) {
-		b.SetCoinbase(common.Address{0: byte(seed), 19: byte(i)})
-	})
-	return blocks
-}
-
 type fakeChainReader struct {
 	config *params.ChainConfig
 }
@@ -388,22 +384,20 @@ func (cr *fakeChainReader) GetLinkExternalBlocks(header *types.Header) ([]*types
 // Blocks created by GenerateNetwork do not contain valid proof of work values.
 // Inserting them into BlockChain requires use of a TestPoW in order to test and
 // verify the correct operation of the Proof-of-Work algorithm.
-func GenerateNetwork(genesisCheck bool, config *params.ChainConfig, parent *types.Block, order int, startNumber [3]int, n int, engine consensus.Engine, db ethdb.Database, gen func(int, *BlockGen)) ([]*types.Block, []types.Receipts) {
+func GenerateBlock(genesisCheck bool, config *params.ChainConfig, parent *types.Block, order int, startNumber [3]int, engine consensus.Engine, db ethdb.Database) *types.Block {
 	// initialize blocks and receipts
-	blocks, receipts := make(types.Blocks, n), make([]types.Receipts, n)
+	block := types.Block{}
 
 	// associate chainreaders and configs for correct block context placement
 	chainreader := fakeChainReader{config: config}
 
-	genblock := func(genCheck bool, i int, parent *types.Block, order int, statedb *state.StateDB, chainreader fakeChainReader, config params.ChainConfig) (*types.Block, types.Receipts) {
+	genblock := func(genCheck bool, parent *types.Block, order int, statedb *state.StateDB, chainreader fakeChainReader, config params.ChainConfig) *types.Block {
 
-		b := &BlockGen{i: i, chain: blocks, parent: parent, statedb: statedb, config: &config, engine: engine}
+		b := &BlockGen{chain: types.Blocks{&block}, parent: parent, statedb: statedb, config: &config, engine: engine}
 		b.header = makeHeader(genCheck, &config, &chainreader, parent, order, statedb, b.engine)
 
 		// Execute any user modifications to the block
-		if gen != nil {
-			gen(i, b)
-		}
+		// for modifications want new logic - come back to later
 
 		if b.engine != nil {
 			// Finalize and seal the block
@@ -417,23 +411,19 @@ func GenerateNetwork(genesisCheck bool, config *params.ChainConfig, parent *type
 			if err := statedb.Database().TrieDB().Commit(root, false, nil); err != nil {
 				panic(fmt.Sprintf("trie write error: %v", err))
 			}
-			return block, b.receipts
+			return block
 		}
-		return nil, nil
+		return nil
 	}
 
-	for i := 0; i < n; i++ {
-		statedb, err := state.New(parent.Root(), state.NewDatabase(db), nil)
-		if err != nil {
-			panic(err)
-		}
-		block, receipt := genblock(genesisCheck, i, parent, order, statedb, chainreader, *config)
-		if genesisCheck { // in order to generate genesis first and only once
-			genesisCheck = false
-		}
-		blocks[i] = block
-		receipts[i] = receipt
-		parent = block
+	statedb, err := state.New(parent.Root(), state.NewDatabase(db), nil)
+	if err != nil {
+		panic(err)
 	}
-	return blocks, receipts
+	block = *genblock(genesisCheck, parent, order, statedb, chainreader, *config)
+	if genesisCheck { // in order to generate genesis first and only once
+		genesisCheck = false
+	}
+
+	return &block
 }

--- a/core/chain_makers_test.go
+++ b/core/chain_makers_test.go
@@ -296,6 +296,20 @@ func findLast(specs []blockSpecs) (lastNumbers [3]int) {
 	return lastNumbers
 }
 
+// finds parent for each block to be generated
+func findParent(blockPool []*types.Block, parentNumbers [3]int) *types.Block {
+	parent := types.Block{}
+	for i := range blockPool {
+		if blockPool[len(blockPool)-1-i].Header().Number[0].Cmp(big.NewInt(int64(parentNumbers[0]))) == 0 &&
+			blockPool[len(blockPool)-1-i].Header().Number[1].Cmp(big.NewInt(int64(parentNumbers[1]))) == 0 &&
+			blockPool[len(blockPool)-1-i].Header().Number[2].Cmp(big.NewInt(int64(parentNumbers[2]))) == 0 {
+			parent = *blockPool[len(blockPool)-1-i]
+			break
+		}
+	}
+	return &parent
+}
+
 // ExampleGenerateNetwork follows the logic of ExampleGenerateChain but
 // with additional parameters to specify intended context of blocks.
 // This makes it possible to test interchain linkages, external transactions,
@@ -360,6 +374,8 @@ func ExampleGenerateNetwork() {
 		if specs.number == [3]int{0, 0, 0} {
 			genesisCheck = true
 			parent = genesisPrime
+		} else {
+			parent = findParent(blockPool, specs.parentNumbers)
 		}
 
 		block := GenerateBlock(genesisCheck, &specs.slice,

--- a/core/chain_makers_test.go
+++ b/core/chain_makers_test.go
@@ -348,20 +348,19 @@ func ExampleGenerateNetwork() {
 		fmt.Println("wrong genesis")
 	}
 
-	// temp
-	parent := genesisPrime
-
-	// genesis handling - should only trigger once, necessary to generate genesis block first and only once
+	// genesis handling - should only trigger once
 	var genesisCheck bool = false
-	if specsPool[0].number == [3]int{0, 0, 0} {
-		genesisCheck = true
-	}
+	var parent *types.Block
 
 	// Generator section
 	// loop over GenerateNetwork
 	blockPool := []*types.Block{}
 	for _, specs := range specsPool {
 		// function here to derive appropriate parent post-genesis cases
+		if specs.number == [3]int{0, 0, 0} {
+			genesisCheck = true
+			parent = genesisPrime
+		}
 
 		block := GenerateBlock(genesisCheck, &specs.slice,
 			parent, specs.order, specs.number,

--- a/core/chain_makers_test.go
+++ b/core/chain_makers_test.go
@@ -28,20 +28,23 @@ import (
 	"github.com/spruce-solutions/go-quai/params"
 )
 
+/*
 func ExampleGenerateChain() {
 	var (
-		key1, _ = crypto.HexToECDSA("b71c71a67e1177ad4e901695e1b4b9ee17ae16c6668d313eac2f96dbcda3f291")
-		key2, _ = crypto.HexToECDSA("8a1f9a8f95be41cd7ccb6168179afb4504aefe388d1e14474d32c45c72ce7b7a")
-		key3, _ = crypto.HexToECDSA("49a7b37aa6f6645917e7b807e9d1c00d4fa71f18343b0d4122a4d2df64dd6fee")
-		addr1   = crypto.PubkeyToAddress(key1.PublicKey)
-		addr2   = crypto.PubkeyToAddress(key2.PublicKey)
-		addr3   = crypto.PubkeyToAddress(key3.PublicKey)
-		db      = rawdb.NewMemoryDatabase()
+		key1, _  = crypto.HexToECDSA("e5406fa9618589dbebc2ff870ab671290e194b0512ec9b85be47287bb59d83dd")
+		key2, _  = crypto.HexToECDSA("36050ddb1cee3a529c0859c15c48e19835629a79ff91520a4299bc232a132ce5")
+		key3, _  = crypto.HexToECDSA("7f677908d2305884aa3b4b909c32e4752c6ec30c6f68eb240c7366c652dda351")
+		addr1    = crypto.PubkeyToAddress(key1.PublicKey)
+		addr2    = crypto.PubkeyToAddress(key2.PublicKey)
+		addr3    = crypto.PubkeyToAddress(key3.PublicKey)
+		db       = rawdb.NewMemoryDatabase()
+		gasPrice = big.NewInt(1)
 	)
 
 	// Ensure that key1 has some funds in the genesis block.
-	gspec := &Genesis{
-		Config: &params.ChainConfig{HomesteadBlock: new(big.Int)},
+	// genesisHashes := []common.Hash{params.RopstenPrimeGenesisHash, params.RopstenRegionGenesisHash, params.RopstenZoneGenesisHash}
+	gspec := &Genesis{ // params.TestChainConfig config parameters
+		Config: &params.ChainConfig{big.NewInt(1337), 0, []byte{0, 0}, []int{3, 3, 3}, big.NewInt(0), big.NewInt(0), common.Hash{}, big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), nil, new(params.blake3Config), nil, nil},
 		Alloc:  GenesisAlloc{addr1: {Balance: big.NewInt(1000000)}},
 	}
 	genesis := gspec.MustCommit(db)
@@ -54,13 +57,13 @@ func ExampleGenerateChain() {
 		switch i {
 		case 0:
 			// In block 1, addr1 sends addr2 some ether.
-			tx, _ := types.SignTx(types.NewTransaction(gen.TxNonce(addr1), addr2, big.NewInt(10000), params.TxGas, nil, nil), signer, key1)
+			tx, _ := types.SignTx(types.NewTransaction(gen.TxNonce(addr1), addr2, big.NewInt(100000), params.TxGas, gasPrice, nil), signer, key1)
 			gen.AddTx(tx)
 		case 1:
 			// In block 2, addr1 sends some more ether to addr2.
 			// addr2 passes it on to addr3.
-			tx1, _ := types.SignTx(types.NewTransaction(gen.TxNonce(addr1), addr2, big.NewInt(1000), params.TxGas, nil, nil), signer, key1)
-			tx2, _ := types.SignTx(types.NewTransaction(gen.TxNonce(addr2), addr3, big.NewInt(1000), params.TxGas, nil, nil), signer, key2)
+			tx1, _ := types.SignTx(types.NewTransaction(gen.TxNonce(addr1), addr2, big.NewInt(10000), params.TxGas, gasPrice, nil), signer, key1)
+			tx2, _ := types.SignTx(types.NewTransaction(gen.TxNonce(addr2), addr3, big.NewInt(1000), params.TxGas, gasPrice, nil), signer, key2)
 			gen.AddTx(tx1)
 			gen.AddTx(tx2)
 		case 2:
@@ -97,4 +100,218 @@ func ExampleGenerateChain() {
 	// balance of addr1: 989000
 	// balance of addr2: 10000
 	// balance of addr3: 19687500000000001000
+} */
+
+// Runner function
+func chainsValidator(chains [][]*types.Block, primeChain BlockChain, regionChain BlockChain, zoneChain BlockChain, ordersPool []chainOrders) (validNetwork [3]BlockChain) {
+	// ordersPool = permutePoool(ordersPool)
+
+	for i := range ordersPool {
+		chain := chains[i]
+		if _, err := primeChain.InsertChain(chain); err != nil {
+			print(err)
+		}
+		// insert each block at their respective contexts
+		/*for i, order := range orders.orders {
+			switch order {
+			case 0:
+				if chain[i] != primeChain.genesisBlock {
+					if _, err := primeChain.InsertChain(types.Blocks{chain[i]}); err != nil {
+						print(err)
+					}
+				}
+			case 1:
+				if _, err := regionChain.InsertChain(types.Blocks{chain[i]}); err != nil {
+					print(err)
+				}
+			case 2:
+				if _, err := zoneChain.InsertChain(types.Blocks{chain[i]}); err != nil {
+					print(err)
+				}
+			}
+		}*/
+	}
+
+	validNetwork = [3]BlockChain{primeChain, regionChain, zoneChain}
+
+	return validNetwork
 }
+
+// ExampleGenerateNetwork follows the logic of ExampleGenerateChain but
+// with additional parameters to specify intended context of blocks.
+// This makes it possible to test interchain linkages, external transactions,
+// and more.
+func ExampleGenerateNetwork() {
+	// keys might need to be changed to conform to Guarded Address Space standards
+	var (
+		key1, _ = crypto.HexToECDSA("e5406fa9618589dbebc2ff870ab671290e194b0512ec9b85be47287bb59d83dd")
+		// key2, _  = crypto.HexToECDSA("36050ddb1cee3a529c0859c15c48e19835629a79ff91520a4299bc232a132ce5")
+		// key3, _  = crypto.HexToECDSA("7f677908d2305884aa3b4b909c32e4752c6ec30c6f68eb240c7366c652dda351")
+		addr1 = crypto.PubkeyToAddress(key1.PublicKey)
+		// addr2    = crypto.PubkeyToAddress(key2.PublicKey)
+		// addr3    = crypto.PubkeyToAddress(key3.PublicKey)
+		db = rawdb.NewMemoryDatabase()
+	)
+
+	// Ensure that key1 has some funds in the genesis block.
+	gspecPrime := &Genesis{
+		Config: params.MainnetPrimeChainConfig,
+		Alloc:  GenesisAlloc{addr1: {Balance: big.NewInt(1000000)}},
+	}
+
+	// start a database object and commit genesis blocks to it
+	primeConfig, genesis, err := SetupGenesisBlock(db, gspecPrime)
+	if err != nil {
+		fmt.Println(err)
+	}
+
+	// load Region and Zone configs
+	regionConfig := params.MainnetRegionChainConfigs[0]
+	zoneConfig := params.MainnetZoneChainConfigs[0][0]
+
+	// create Geneis blocks in respective chains
+	genesisPrime := gspecPrime.MustCommit(db)
+
+	// ordersPool constructor - feed notation in here to construct
+	// sets of orders that can be passed into the generator one at
+	// a time and placed into a pool
+
+	// IMPORTANT TO NOTE: sequence of blocks generated must be sequential,
+	// i.e. you cannot generate a 75th block w/out first generating the 74th block
+	// AFTER generation, ordersPool can be permuted in all possible ways and
+	// passed into the Runner
+
+	// establish desired contexts for generated blocks
+	// orders must descend i.e. a Prime block must come before any Region blocks, and a Region block must come before any Zone blocks
+	chainOrders1 := chainOrders{
+		orders:      []int{0, 1, 2, 2, 1, 0}, // {0,1,2,2,1} represents Prime, Region, Zone, Zone, Region
+		startNumber: []int{0, 0, 0},
+	}
+	ordersPool := []chainOrders{chainOrders1}
+
+	// Import the chain. This runs all block validation rules.
+	blockchainPrime, _ := NewBlockChain(db, defaultCacheConfig, primeConfig, blake3.NewFaker(), vm.Config{}, nil, nil)
+	defer blockchainPrime.Stop()
+	blockchainRegion, _ := NewBlockChain(db, defaultCacheConfig, &regionConfig, blake3.NewFaker(), vm.Config{}, nil, nil)
+	defer blockchainRegion.Stop()
+	blockchainZone, _ := NewBlockChain(db, defaultCacheConfig, &zoneConfig, blake3.NewFaker(), vm.Config{}, nil, nil)
+	defer blockchainZone.Stop()
+
+	if genesis != blockchainPrime.genesisBlock.Hash() {
+		fmt.Println("wrong genesis")
+	}
+
+	// temp
+	parent := genesisPrime
+
+	// Generator section
+	// loop over GenerateNetwork
+	chains := [][]*types.Block{}
+	for _, orders := range ordersPool {
+		// parent := blockchainPrime.GetBlockByNumber(uint64(orders.parent[0]))
+		chain, _ := GenerateNetwork(primeConfig, regionConfig, zoneConfig,
+			parent, orders.orders, orders.startNumber,
+			blake3.NewFaker(), db, func(i int, gen *BlockGen) {
+				switch i { // preserve this section for testing transaction data
+				/* case 0:
+
+				case 1:
+
+				case 2:
+
+				case 3:
+
+				case 4:
+				*/
+				}
+			})
+		chains = append(chains, chain)
+	}
+
+	// Runner section
+	validNetwork := chainsValidator(chains, *blockchainPrime, *blockchainRegion, *blockchainZone, ordersPool)
+	blockchainPrime = &validNetwork[0]
+	blockchainRegion = &validNetwork[1]
+	blockchainZone = &validNetwork[2]
+
+	statePrime, _ := blockchainPrime.State()
+	stateRegion, _ := blockchainRegion.State()
+	stateZone, _ := blockchainZone.State()
+
+	fmt.Println("balance of addr1 in Prime:", statePrime.GetBalance(addr1))
+	fmt.Println("balance of addr1 in Region 1:", stateRegion.GetBalance(addr1))
+	fmt.Println("balance of addr1 in Zone 1-1:", stateZone.GetBalance(addr1))
+	// Output:
+	// Current Header Number [0 0 0] 0xc9bada59c70cb15feeab18e408a5e9b1938e7abdca9b0bed1193b52d9b6edc2e
+	// Current Header Number [0 0 0] 0xc9bada59c70cb15feeab18e408a5e9b1938e7abdca9b0bed1193b52d9b6edc2e
+	// Current Header Number [0 0 0] 0xc9bada59c70cb15feeab18e408a5e9b1938e7abdca9b0bed1193b52d9b6edc2e
+	// balance of addr1 in Prime: 1000000
+	// balance of addr1 in Region 1: 1000000
+	// balance of addr1 in Zone 1-1: 1000000
+}
+
+// struct for interpreting notation/constructing chains
+type blockConstructor struct {
+	numbers [3]int // prime idx, region idx, zone idx
+	// -1 for contexts the block does not coincide with
+	parentTags [3]string // (optionally) Override the parents to point to tagged blocks. Empty strings are ignored.
+	tag        string    // (optionally) Give this block a named tag. Empty strings are ignored.
+}
+
+// Constant Genesis definition
+var genesisBlock = blockConstructor{[3]int{0, 0, 0}, [3]string{}, ""}
+
+type chainOrders struct {
+	orders      []int // sequence of orders to grind
+	startNumber []int // Number to start at (also used to derive parent)
+	parent      []int //
+	parentTags  [3]string
+	tag         string
+}
+
+// simple example graph
+// [3][3][100]*blockConstructor = 3 regions, each w/ 3 zones, each w/ 100 blocks
+var networkGraph = [1][1][6]*blockConstructor{
+	{ // Region1
+		{ // Zone1
+			&genesisBlock,
+			&blockConstructor{[3]int{0, 1, 1}, [3]string{}, ""},
+			&blockConstructor{[3]int{0, 1, 2}, [3]string{}, ""},
+			&blockConstructor{[3]int{0, 1, 3}, [3]string{}, ""},
+			&blockConstructor{[3]int{0, 2, 4}, [3]string{}, ""},
+			&blockConstructor{[3]int{1, 3, 5}, [3]string{}, ""},
+		},
+	},
+}
+
+/*
+func BlockInterpreter(networkGraph [][][]*blockConstructor) []chainOrders {
+
+	chains := []chainOrders{}
+	for _, regionSlice := range networkGraph {
+		for _, zoneSlice := range regionSlice {
+			chain := chainOrders{}
+			prime := 0
+			region := 0
+			zone := 0
+
+			for i, block := range zoneSlice {
+				if i == 0 {
+					chain.parent = []int{prime, region, zone}
+					chain.parentTags = block.parentTags
+					chain.tag = block.tag
+				}
+				if block == genesisBlock {
+					chain.orders[i] = 0 // selects order in slice
+					chain.startNumber = []int{0, 0, 0}
+					chain.parent = nil // remember to assign genesis
+				} else {
+
+				}
+			}
+		}
+	}
+
+	return chains
+}
+*/

--- a/params/config.go
+++ b/params/config.go
@@ -55,7 +55,7 @@ var CheckpointOracles = map[common.Hash]*CheckpointOracleConfig{
 }
 var mainnetValidChains = []*big.Int{big.NewInt(9000), big.NewInt(9100), big.NewInt(9101), big.NewInt(9102), big.NewInt(9103), big.NewInt(9200), big.NewInt(9201), big.NewInt(9202), big.NewInt(9203), big.NewInt(9300), big.NewInt(9301), big.NewInt(9302), big.NewInt(9303)}
 
-var testnetValidChains = []*big.Int{big.NewInt(12000), big.NewInt(12100), big.NewInt(12101), big.NewInt(12102), big.NewInt(12103), big.NewInt(12200), big.NewInt(12201), big.NewInt(12202), big.NewInt(12203), big.NewInt(12300), big.NewInt(12301), big.NewInt(12302), big.NewInt(12303)}
+var testnetValidChains = []*big.Int{big.NewInt(12000), big.NewInt(12100), big.NewInt(12101), big.NewInt(12102), big.NewInt(12103), big.NewInt(12200), big.NewInt(12201), big.NewInt(12202), big.NewInt(12203), big.NewInt(12300), big.NewInt(12301), big.NewInt(12302), big.NewInt(12303), big.NewInt(1337)}
 
 var (
 	// MainnetPrimeChainConfig is the chain parameters to run a node on the main network.
@@ -1140,20 +1140,21 @@ var (
 	testnetBytePrefixList = make([][]int, 20000)
 )
 
+// Guarded Address Space ranges
 func init() {
-	mainnetBytePrefixList[9000] = []int{0, 9}
-	mainnetBytePrefixList[9100] = []int{10, 19}
-	mainnetBytePrefixList[9101] = []int{20, 29}
-	mainnetBytePrefixList[9102] = []int{30, 39}
-	mainnetBytePrefixList[9103] = []int{40, 49}
-	mainnetBytePrefixList[9200] = []int{50, 59}
-	mainnetBytePrefixList[9201] = []int{60, 69}
-	mainnetBytePrefixList[9202] = []int{70, 79}
-	mainnetBytePrefixList[9203] = []int{80, 89}
-	mainnetBytePrefixList[9300] = []int{90, 99}
-	mainnetBytePrefixList[9301] = []int{100, 109}
-	mainnetBytePrefixList[9302] = []int{110, 119}
-	mainnetBytePrefixList[9303] = []int{120, 129}
+	mainnetBytePrefixList[9000] = []int{0, 9}     // Prime
+	mainnetBytePrefixList[9100] = []int{10, 19}   // Cyprus
+	mainnetBytePrefixList[9101] = []int{20, 29}   // Cyprus One
+	mainnetBytePrefixList[9102] = []int{30, 39}   // Cyprus Two
+	mainnetBytePrefixList[9103] = []int{40, 49}   // Cyprus Three
+	mainnetBytePrefixList[9200] = []int{50, 59}   // Paxos
+	mainnetBytePrefixList[9201] = []int{60, 69}   // Paxos One
+	mainnetBytePrefixList[9202] = []int{70, 79}   // Paxos Two
+	mainnetBytePrefixList[9203] = []int{80, 89}   // Paxos Three
+	mainnetBytePrefixList[9300] = []int{90, 99}   // Hydra
+	mainnetBytePrefixList[9301] = []int{100, 109} // Hydra One
+	mainnetBytePrefixList[9302] = []int{110, 119} // Hydra Two
+	mainnetBytePrefixList[9303] = []int{120, 129} // Hydra Three
 
 	testnetBytePrefixList[12000] = []int{0, 9}
 	testnetBytePrefixList[12100] = []int{10, 19}
@@ -1168,6 +1169,7 @@ func init() {
 	testnetBytePrefixList[12301] = []int{100, 109}
 	testnetBytePrefixList[12302] = []int{110, 119}
 	testnetBytePrefixList[12303] = []int{120, 129}
+	testnetBytePrefixList[1337] = []int{0, 129} // for integration tests
 }
 
 // ChainIDRange returns the byte lookup based off a configs chainID

--- a/params/config.go
+++ b/params/config.go
@@ -55,7 +55,7 @@ var CheckpointOracles = map[common.Hash]*CheckpointOracleConfig{
 }
 var mainnetValidChains = []*big.Int{big.NewInt(9000), big.NewInt(9100), big.NewInt(9101), big.NewInt(9102), big.NewInt(9103), big.NewInt(9200), big.NewInt(9201), big.NewInt(9202), big.NewInt(9203), big.NewInt(9300), big.NewInt(9301), big.NewInt(9302), big.NewInt(9303)}
 
-var testnetValidChains = []*big.Int{big.NewInt(12000), big.NewInt(12100), big.NewInt(12101), big.NewInt(12102), big.NewInt(12103), big.NewInt(12200), big.NewInt(12201), big.NewInt(12202), big.NewInt(12203), big.NewInt(12300), big.NewInt(12301), big.NewInt(12302), big.NewInt(12303), big.NewInt(1337)}
+var testnetValidChains = []*big.Int{big.NewInt(12000), big.NewInt(12100), big.NewInt(12101), big.NewInt(12102), big.NewInt(12103), big.NewInt(12200), big.NewInt(12201), big.NewInt(12202), big.NewInt(12203), big.NewInt(12300), big.NewInt(12301), big.NewInt(12302), big.NewInt(12303)}
 
 var (
 	// MainnetPrimeChainConfig is the chain parameters to run a node on the main network.
@@ -917,7 +917,6 @@ func (c *ChainConfig) IsFuller(num *big.Int) bool {
 func (c *ChainConfig) IsTuring(num *big.Int) bool {
 	return isForked(c.TuringMapContext, num)
 }
-
 // IsLovelace returns whether num is either equal to the Merge fork block or greater.
 func (c *ChainConfig) IsLovelace(num *big.Int) bool {
 	return isForked(c.LovelaceMapContext, num)
@@ -1140,21 +1139,20 @@ var (
 	testnetBytePrefixList = make([][]int, 20000)
 )
 
-// Guarded Address Space ranges
 func init() {
-	mainnetBytePrefixList[9000] = []int{0, 9}     // Prime
-	mainnetBytePrefixList[9100] = []int{10, 19}   // Cyprus
-	mainnetBytePrefixList[9101] = []int{20, 29}   // Cyprus One
-	mainnetBytePrefixList[9102] = []int{30, 39}   // Cyprus Two
-	mainnetBytePrefixList[9103] = []int{40, 49}   // Cyprus Three
-	mainnetBytePrefixList[9200] = []int{50, 59}   // Paxos
-	mainnetBytePrefixList[9201] = []int{60, 69}   // Paxos One
-	mainnetBytePrefixList[9202] = []int{70, 79}   // Paxos Two
-	mainnetBytePrefixList[9203] = []int{80, 89}   // Paxos Three
-	mainnetBytePrefixList[9300] = []int{90, 99}   // Hydra
-	mainnetBytePrefixList[9301] = []int{100, 109} // Hydra One
-	mainnetBytePrefixList[9302] = []int{110, 119} // Hydra Two
-	mainnetBytePrefixList[9303] = []int{120, 129} // Hydra Three
+	mainnetBytePrefixList[9000] = []int{0, 9}
+	mainnetBytePrefixList[9100] = []int{10, 19}
+	mainnetBytePrefixList[9101] = []int{20, 29}
+	mainnetBytePrefixList[9102] = []int{30, 39}
+	mainnetBytePrefixList[9103] = []int{40, 49}
+	mainnetBytePrefixList[9200] = []int{50, 59}
+	mainnetBytePrefixList[9201] = []int{60, 69}
+	mainnetBytePrefixList[9202] = []int{70, 79}
+	mainnetBytePrefixList[9203] = []int{80, 89}
+	mainnetBytePrefixList[9300] = []int{90, 99}
+	mainnetBytePrefixList[9301] = []int{100, 109}
+	mainnetBytePrefixList[9302] = []int{110, 119}
+	mainnetBytePrefixList[9303] = []int{120, 129}
 
 	testnetBytePrefixList[12000] = []int{0, 9}
 	testnetBytePrefixList[12100] = []int{10, 19}
@@ -1169,7 +1167,6 @@ func init() {
 	testnetBytePrefixList[12301] = []int{100, 109}
 	testnetBytePrefixList[12302] = []int{110, 119}
 	testnetBytePrefixList[12303] = []int{120, 129}
-	testnetBytePrefixList[1337] = []int{0, 129} // for integration tests
 }
 
 // ChainIDRange returns the byte lookup based off a configs chainID


### PR DESCRIPTION
Should be close to finished, minus a gap in logic (currently in progress) the entire idea is there.

The test starts at ExampleGenerateNetwork in chain_makers_test.go, then BlockInterpreter is used to derive a set of specs from the networkGraph, then these specs are looped over GenerateBlock (chain_makers.go) to create a pool of blocks that can then be passed to a Runner to test validation and fork scenarios.

Edits to files outside the two mentioned are fixes for the new Blake3 faker engine used for making sure blocks are created in the right part of the hierarchy.