### PR TITLE
Boiler plate & test framework for fork choice tests

### DIFF
--- a/core/chain_fork_tests.go
+++ b/core/chain_fork_tests.go
@@ -1,0 +1,75 @@
+package core
+
+import (
+	"errors"
+	"math/big"
+
+	"github.com/spruce-solutions/go-quai/common"
+	"github.com/spruce-solutions/go-quai/core/types"
+)
+
+// Generate blocks to form a network of chains
+func SendNetworkBlocksToNode(graph [3][3][]*blockGenSpec, blocks []*types.Block) error {
+	return errors.New("Not implemented")
+}
+
+func GetNodeHeadAndTD() (common.Hash, [3]*big.Int, error) {
+	return common.Hash{}, [3]*big.Int{}, errors.New("Not implemented")
+}
+
+// Example test for a fork choice scenario shown in slide00 (not a real slide)
+func ForkChoiceTest_Slide00() {
+	// Define the network graph here
+	graph := [3][3][]*blockGenSpec{
+		{ // Region0
+			{ // Zone0
+				&blockGenSpec{[3]int{1, 1, 1}, [3]string{}, "z00_1"},
+				&blockGenSpec{[3]int{-1, -1, 2}, [3]string{}, ""},
+				// ...
+				&blockGenSpec{[3]int{-1, 2, 4}, [3]string{}, "z00_4"},
+				&blockGenSpec{[3]int{3, 3, 5}, [3]string{}, ""},
+				&blockGenSpec{[3]int{-1, -1, 6}, [3]string{}, ""},                // END OF CANONICAL CHAIN
+				&blockGenSpec{[3]int{-1, -1, 5}, [3]string{"", "", "z00_4"}, ""}, // Fork at z00_4
+				// ...
+				&blockGenSpec{[3]int{-1, 3, 8}, [3]string{}, ""},
+				&blockGenSpec{[3]int{-1, -1, 5}, [3]string{"", "", "z00_4"}, ""}, // Fork at z00_4
+				&blockGenSpec{[3]int{-1, -1, 6}, [3]string{}, ""},
+				&blockGenSpec{[3]int{-1, -1, 7}, [3]string{"", "z00_1", ""}, ""}, // Twist to z00_1
+			},
+			{}, // ... Zone1 omitted
+			{}, // ... Zone2 omitted
+		},
+		{ // Region1
+			{ // Zone0
+				&blockGenSpec{[3]int{1, 1, 2}, [3]string{"", "", "z00_1"}, ""},
+			},
+			{}, // ... Zone1 omitted
+			{}, // ... Zone2 omitted
+		},
+		{}, // ... Region2 omitted
+	}
+
+	// Generate the blocks for this graph
+	blocks, err := GenerateNetworkBlocks(graph)
+	if err != nil {
+		panic("Error generating blocks!")
+	}
+
+	// Send internal & external blocks to the node
+	err = SendNetworkBlocksToNode(graph, blocks)
+	if err != nil {
+		panic("Failed to send all blocks to the node!")
+	}
+
+	// Confirm the node arrived at the expected head, with the expected total difficulty
+	expectedHead := common.Hash{}
+	expectedTD := [3]*big.Int{big.NewInt(0), big.NewInt(0), big.NewInt(0)}
+	head, td, err := GetNodeHeadAndTD()
+	if err != nil {
+		panic("Error getting node head & total difficulty!")
+	} else if head != expectedHead {
+		panic("Node is on the wrong head!")
+	} else if td != expectedTD {
+		panic("Node has the wrong total difficulty!")
+	}
+}

--- a/core/chain_makers.go
+++ b/core/chain_makers.go
@@ -17,6 +17,7 @@
 package core
 
 import (
+	"errors"
 	"fmt"
 	"math/big"
 
@@ -309,6 +310,18 @@ func makeBlockChain(parent *types.Block, n int, engine consensus.Engine, db ethd
 		b.SetCoinbase(common.Address{0: byte(seed), 19: byte(i)})
 	})
 	return blocks
+}
+
+// struct for notation
+type blockGenSpec struct {
+	numbers    [3]int    // prime idx, region idx, zone idx
+	parentTags [3]string // (optionally) Override the parents to point to tagged blocks. Empty strings are ignored.
+	tag        string    // (optionally) Give this block a named tag. Empty strings are ignored.
+}
+
+// Generate blocks to form a network of chains
+func GenerateNetworkBlocks(graph [3][3][]*blockGenSpec) ([]*types.Block, error) {
+	return nil, errors.New("Not implemented")
 }
 
 type fakeChainReader struct {


### PR DESCRIPTION
@BryceAgent & @williamdboyd this PR attempts to establish the framework for fork choice tests. I expect your work to extend this framework. Notice I have not implemented several of the key functions, those remain to be implemented by all three of us.

@BryceAgent I left review comments in your PR to this effect, but please move any logic not related to testing chain makers our of `chain_makers_test.go`. Logic necessary to implement fork choice tests should go in the new `fork_choice_tests.go` file instead. **Your block generator should become the implementation of `GenerateNetworkBlocks()`. Please make be sure your implementation satisfies that requirement.**

@williamdboyd the tests you are writing should become new copies of the `ForkChoiceTest_Slide00()` function I give below. e.g. when you write the test case for slide 1, create a new copy of this function called `ForkChoiceTest_Slide01()` and change the `graph` definition to match the slide.

I will focus on implementing the functions to send blocks to the node and to check the pass/fail criteria of each test. With this PR, everything should be orthogonal, and we should be able to work in parallel without conflicts.

Please take a look at this PR and share your feedback. If everyone agrees on this PR, I will merge it and we will march towards this as the finish-line for automated fork choice tests.