### PR TITLE
core/blockchain.go: reverted the reorgTwistToCommonAncestor

### DIFF
--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -3120,7 +3120,7 @@ func (bc *BlockChain) PCRC(header *types.Header) (common.Hash, error) {
 			// 2. If Zone terminus is in our chain, do nothing.
 			// 3. If Zone terminus is not in our chain, uncle the RTZ in the subordinate context.
 			if types.QuaiNetworkContext <= params.REGION {
-				err = bc.reorgTwistToCommonAncestor(RTZ, RTR, slice, params.REGION, params.ZONE)
+				err = bc.reorgTwistToCommonAncestor(RTZ, slice, params.REGION, params.ZONE)
 				if err != nil {
 					return common.Hash{}, errors.New("unable to reorg to common ancestor after region twist")
 				}
@@ -3155,7 +3155,7 @@ func (bc *BlockChain) PCRC(header *types.Header) (common.Hash, error) {
 		if PTR.Hash() != PTP.Hash() {
 			log.Info("Error in PCRC", "PTR:", PTR.Hash(), "RTR:", PTP.Hash())
 			if types.QuaiNetworkContext == params.PRIME {
-				err = bc.reorgTwistToCommonAncestor(PTR, PTP, slice, params.PRIME, params.REGION)
+				err = bc.reorgTwistToCommonAncestor(PTR, slice, params.PRIME, params.REGION)
 				if err != nil {
 					return common.Hash{}, errors.New("unable to reorg to common ancestor after prime (PTP) twist")
 				}
@@ -3166,7 +3166,7 @@ func (bc *BlockChain) PCRC(header *types.Header) (common.Hash, error) {
 		if PTZ.Hash() != PTR.Hash() {
 			log.Info("Error in PCRC", "PTZ:", PTZ.Hash(), "PTR:", PTR.Hash())
 			if types.QuaiNetworkContext == params.PRIME {
-				err = bc.reorgTwistToCommonAncestor(PTZ, PTR, slice, params.PRIME, params.ZONE)
+				err = bc.reorgTwistToCommonAncestor(PTZ, slice, params.PRIME, params.ZONE)
 				if err != nil {
 					return common.Hash{}, errors.New("unable to reorg to common ancestor after prime (PTR) twist")
 				}
@@ -3183,7 +3183,7 @@ func (bc *BlockChain) PCRC(header *types.Header) (common.Hash, error) {
 // This uncle will rollback the subordinate chain in the manager process.
 // If there are many invalid subordinate heads, aggregate the valid subordinate blocks (NewSubs) off of the valid dominant chain (RTR / PTP / PTR)
 // and include them for processing in the manager.
-func (bc *BlockChain) reorgTwistToCommonAncestor(subHead *types.Header, domHead *types.Header, slice []byte, order int, path int) error {
+func (bc *BlockChain) reorgTwistToCommonAncestor(subHead *types.Header, slice []byte, order int, path int) error {
 	num := bc.hc.GetBlockNumber(subHead.Hash())
 
 	if num != nil {
@@ -3201,13 +3201,8 @@ func (bc *BlockChain) reorgTwistToCommonAncestor(subHead *types.Header, domHead 
 		num = bc.hc.GetBlockNumber(prevHeader.Hash())
 
 		if num != nil {
-			// get all the external blocks on the subordinate chain path until common point
-			extBlocks, err := bc.GetExternalBlockTraceSet(prevHeader.Hash(), domHead, path)
-			if err != nil {
-				return err
-			}
 			// Remove non-cononical blocks from subordinate chains.
-			bc.reOrgFeed.Send(ReOrgRollup{ReOrgHeader: prev, OldChainHeaders: []*types.Header{prev}, NewChainHeaders: []*types.Header{domHead}, NewSubs: extBlocks})
+			bc.chainUncleFeed.Send(prev)
 			return nil
 		}
 		prev = prevHeader


### PR DESCRIPTION
core/blockchain.go: reverted the reorgTwistToCommonAncestor to use the uncle feed and send the last num==nil block