### PR TITLE
DEV ONLY: made modifications to allow us to dev without dropping peers.

### DIFF
--- a/eth/handler.go
+++ b/eth/handler.go
@@ -357,10 +357,10 @@ func (h *handler) runSnapExtension(peer *snap.Peer, handler snap.Handler) error 
 
 // removePeer requests disconnection of a peer.
 func (h *handler) removePeer(id string) {
-	peer := h.peers.peer(id)
-	if peer != nil {
-		peer.Peer.Disconnect(p2p.DiscUselessPeer)
-	}
+	// peer := h.peers.peer(id)
+	// if peer != nil {
+	// 	peer.Peer.Disconnect(p2p.DiscUselessPeer)
+	// }
 }
 
 // unregisterPeer removes a peer from the downloader, fetchers and main peer set.

--- a/p2p/discover/table.go
+++ b/p2p/discover/table.go
@@ -39,7 +39,7 @@ import (
 )
 
 const (
-	alpha           = 3  // Kademlia concurrency factor
+	alpha           = 6  // Kademlia concurrency factor
 	bucketSize      = 16 // Kademlia bucket size
 	maxReplacements = 10 // Size of per-bucket replacement list
 
@@ -50,13 +50,13 @@ const (
 	bucketMinDistance = hashBits - nBuckets // Log distance of closest bucket
 
 	// IP address limits.
-	bucketIPLimit, bucketSubnet = 2, 24 // at most 2 addresses from the same /24
-	tableIPLimit, tableSubnet   = 10, 24
+	bucketIPLimit, bucketSubnet = 24, 24 // at most 2 addresses from the same /24
+	tableIPLimit, tableSubnet   = 24, 24
 
 	refreshInterval    = 30 * time.Minute
 	revalidateInterval = 10 * time.Second
 	copyNodesInterval  = 30 * time.Second
-	seedMinTableTime   = 5 * time.Minute
+	seedMinTableTime   = 1 * time.Second
 	seedCount          = 30
 	seedMaxAge         = 5 * 24 * time.Hour
 )


### PR DESCRIPTION
This PR disables any peer diversity requirements in the peering client, and allows our node to promiscuously peer to anyone. This is a development feature only, and should not be released officially.